### PR TITLE
removed circle obbject

### DIFF
--- a/api/shapes/area.go
+++ b/api/shapes/area.go
@@ -16,10 +16,6 @@ type Rectangle struct {
 	Height float32 `json:"height"`
 }
 
-type Circle struct {
-	Radius float32 `json:"radius"`
-}
-
 func GetRectangleArea(c *gin.Context) {
 	re := &Rectangle{}
 


### PR DESCRIPTION
Removed circle object from API package.
Mostly used as set up for local and testing for push ability.